### PR TITLE
Respect IntOrString type in schema with `int | str`

### DIFF
--- a/gybe/codegen/k8s_modules.py
+++ b/gybe/codegen/k8s_modules.py
@@ -36,6 +36,9 @@ ignore_models = {
     'StorageVersionSpec',
     'FieldsV1',
 }
+override_fields = {
+    'port': 'int | str',
+}
 
 
 class JSONSchemaProperties(TypedDict):
@@ -207,7 +210,9 @@ class K8sModule:
         for m in ignore_models:
             if m in ref:
                 return 'JSONObj'
-        if ref.endswith('IntOrString') or 'Time' in ref:
+        if ref.endswith('IntOrString'):
+            return 'int | str'
+        elif 'Time' in ref:
             return 'str'
         if import_ != self._module_name:
             self._module_imports.add('import ' + import_)

--- a/gybe/k8s/v1_31/apps/v1.py
+++ b/gybe/k8s/v1_31/apps/v1.py
@@ -412,8 +412,8 @@ class RollingUpdateDaemonSet(K8sSpec):
 
     """
 
-    maxSurge: Optional[str] = None
-    maxUnavailable: Optional[str] = None
+    maxSurge: Optional[int | str] = None
+    maxUnavailable: Optional[int | str] = None
 
 
 @dataclass
@@ -438,8 +438,8 @@ class RollingUpdateDeployment(K8sSpec):
 
     """
 
-    maxSurge: Optional[str] = None
-    maxUnavailable: Optional[str] = None
+    maxSurge: Optional[int | str] = None
+    maxUnavailable: Optional[int | str] = None
 
 
 @dataclass
@@ -461,7 +461,7 @@ class RollingUpdateStatefulSetStrategy(K8sSpec):
 
     """
 
-    maxUnavailable: Optional[str] = None
+    maxUnavailable: Optional[int | str] = None
     partition: Optional[int] = None
 
 

--- a/gybe/k8s/v1_31/core/v1.py
+++ b/gybe/k8s/v1_31/core/v1.py
@@ -1612,7 +1612,7 @@ class HTTPGetAction(K8sSpec):
 
     """
 
-    port: str
+    port: int | str
     host: Optional[str] = None
     httpHeaders: Optional[List[HTTPHeader]] = None
     path: Optional[str] = None
@@ -2997,7 +2997,7 @@ class TCPSocketAction(K8sSpec):
 
     """
 
-    port: str
+    port: int | str
     host: Optional[str] = None
 
 
@@ -4926,7 +4926,7 @@ class ServicePort(K8sSpec):
     name: Optional[str] = None
     nodePort: Optional[int] = None
     protocol: Optional[str] = None
-    targetPort: Optional[str] = None
+    targetPort: Optional[int | str] = None
 
 
 @dataclass

--- a/gybe/k8s/v1_31/networking/v1.py
+++ b/gybe/k8s/v1_31/networking/v1.py
@@ -399,7 +399,7 @@ class NetworkPolicyPort(K8sSpec):
     """
 
     endPort: Optional[int] = None
-    port: Optional[str] = None
+    port: Optional[int | str] = None
     protocol: Optional[str] = None
 
 

--- a/gybe/k8s/v1_31/policy/v1.py
+++ b/gybe/k8s/v1_31/policy/v1.py
@@ -87,8 +87,8 @@ class PodDisruptionBudgetSpec(K8sSpec):
 
     """
 
-    maxUnavailable: Optional[str] = None
-    minAvailable: Optional[str] = None
+    maxUnavailable: Optional[int | str] = None
+    minAvailable: Optional[int | str] = None
     selector: Optional[gybe.k8s.v1_31.meta.v1.LabelSelector] = None
     unhealthyPodEvictionPolicy: Optional[str] = None
 

--- a/gybe/k8s/v1_32/apps/v1.py
+++ b/gybe/k8s/v1_32/apps/v1.py
@@ -412,8 +412,8 @@ class RollingUpdateDaemonSet(K8sSpec):
 
     """
 
-    maxSurge: Optional[str] = None
-    maxUnavailable: Optional[str] = None
+    maxSurge: Optional[int | str] = None
+    maxUnavailable: Optional[int | str] = None
 
 
 @dataclass
@@ -438,8 +438,8 @@ class RollingUpdateDeployment(K8sSpec):
 
     """
 
-    maxSurge: Optional[str] = None
-    maxUnavailable: Optional[str] = None
+    maxSurge: Optional[int | str] = None
+    maxUnavailable: Optional[int | str] = None
 
 
 @dataclass
@@ -461,7 +461,7 @@ class RollingUpdateStatefulSetStrategy(K8sSpec):
 
     """
 
-    maxUnavailable: Optional[str] = None
+    maxUnavailable: Optional[int | str] = None
     partition: Optional[int] = None
 
 

--- a/gybe/k8s/v1_32/core/v1.py
+++ b/gybe/k8s/v1_32/core/v1.py
@@ -1632,7 +1632,7 @@ class HTTPGetAction(K8sSpec):
 
     """
 
-    port: str
+    port: int | str
     host: Optional[str] = None
     httpHeaders: Optional[List[HTTPHeader]] = None
     path: Optional[str] = None
@@ -3041,7 +3041,7 @@ class TCPSocketAction(K8sSpec):
 
     """
 
-    port: str
+    port: int | str
     host: Optional[str] = None
 
 
@@ -5004,7 +5004,7 @@ class ServicePort(K8sSpec):
     name: Optional[str] = None
     nodePort: Optional[int] = None
     protocol: Optional[str] = None
-    targetPort: Optional[str] = None
+    targetPort: Optional[int | str] = None
 
 
 @dataclass

--- a/gybe/k8s/v1_32/networking/v1.py
+++ b/gybe/k8s/v1_32/networking/v1.py
@@ -399,7 +399,7 @@ class NetworkPolicyPort(K8sSpec):
     """
 
     endPort: Optional[int] = None
-    port: Optional[str] = None
+    port: Optional[int | str] = None
     protocol: Optional[str] = None
 
 

--- a/gybe/k8s/v1_32/policy/v1.py
+++ b/gybe/k8s/v1_32/policy/v1.py
@@ -87,8 +87,8 @@ class PodDisruptionBudgetSpec(K8sSpec):
 
     """
 
-    maxUnavailable: Optional[str] = None
-    minAvailable: Optional[str] = None
+    maxUnavailable: Optional[int | str] = None
+    minAvailable: Optional[int | str] = None
     selector: Optional[gybe.k8s.v1_32.meta.v1.LabelSelector] = None
     unhealthyPodEvictionPolicy: Optional[str] = None
 

--- a/gybe/k8s/v1_33/apps/v1.py
+++ b/gybe/k8s/v1_33/apps/v1.py
@@ -423,8 +423,8 @@ class RollingUpdateDaemonSet(K8sSpec):
 
     """
 
-    maxSurge: Optional[str] = None
-    maxUnavailable: Optional[str] = None
+    maxSurge: Optional[int | str] = None
+    maxUnavailable: Optional[int | str] = None
 
 
 @dataclass
@@ -449,8 +449,8 @@ class RollingUpdateDeployment(K8sSpec):
 
     """
 
-    maxSurge: Optional[str] = None
-    maxUnavailable: Optional[str] = None
+    maxSurge: Optional[int | str] = None
+    maxUnavailable: Optional[int | str] = None
 
 
 @dataclass
@@ -472,7 +472,7 @@ class RollingUpdateStatefulSetStrategy(K8sSpec):
 
     """
 
-    maxUnavailable: Optional[str] = None
+    maxUnavailable: Optional[int | str] = None
     partition: Optional[int] = None
 
 

--- a/gybe/k8s/v1_33/core/v1.py
+++ b/gybe/k8s/v1_33/core/v1.py
@@ -1632,7 +1632,7 @@ class HTTPGetAction(K8sSpec):
 
     """
 
-    port: str
+    port: int | str
     host: Optional[str] = None
     httpHeaders: Optional[List[HTTPHeader]] = None
     path: Optional[str] = None
@@ -3043,7 +3043,7 @@ class TCPSocketAction(K8sSpec):
 
     """
 
-    port: str
+    port: int | str
     host: Optional[str] = None
 
 
@@ -5035,7 +5035,7 @@ class ServicePort(K8sSpec):
     name: Optional[str] = None
     nodePort: Optional[int] = None
     protocol: Optional[str] = None
-    targetPort: Optional[str] = None
+    targetPort: Optional[int | str] = None
 
 
 @dataclass

--- a/gybe/k8s/v1_33/networking/v1.py
+++ b/gybe/k8s/v1_33/networking/v1.py
@@ -437,7 +437,7 @@ class NetworkPolicyPort(K8sSpec):
     """
 
     endPort: Optional[int] = None
-    port: Optional[str] = None
+    port: Optional[int | str] = None
     protocol: Optional[str] = None
 
 

--- a/gybe/k8s/v1_33/policy/v1.py
+++ b/gybe/k8s/v1_33/policy/v1.py
@@ -86,8 +86,8 @@ class PodDisruptionBudgetSpec(K8sSpec):
 
     """
 
-    maxUnavailable: Optional[str] = None
-    minAvailable: Optional[str] = None
+    maxUnavailable: Optional[int | str] = None
+    minAvailable: Optional[int | str] = None
     selector: Optional[gybe.k8s.v1_33.meta.v1.LabelSelector] = None
     unhealthyPodEvictionPolicy: Optional[str] = None
 

--- a/gybe/k8s/v1_34/apps/v1.py
+++ b/gybe/k8s/v1_34/apps/v1.py
@@ -423,8 +423,8 @@ class RollingUpdateDaemonSet(K8sSpec):
 
     """
 
-    maxSurge: Optional[str] = None
-    maxUnavailable: Optional[str] = None
+    maxSurge: Optional[int | str] = None
+    maxUnavailable: Optional[int | str] = None
 
 
 @dataclass
@@ -449,8 +449,8 @@ class RollingUpdateDeployment(K8sSpec):
 
     """
 
-    maxSurge: Optional[str] = None
-    maxUnavailable: Optional[str] = None
+    maxSurge: Optional[int | str] = None
+    maxUnavailable: Optional[int | str] = None
 
 
 @dataclass
@@ -472,7 +472,7 @@ class RollingUpdateStatefulSetStrategy(K8sSpec):
 
     """
 
-    maxUnavailable: Optional[str] = None
+    maxUnavailable: Optional[int | str] = None
     partition: Optional[int] = None
 
 

--- a/gybe/k8s/v1_34/core/v1.py
+++ b/gybe/k8s/v1_34/core/v1.py
@@ -1701,7 +1701,7 @@ class HTTPGetAction(K8sSpec):
 
     """
 
-    port: str
+    port: int | str
     host: Optional[str] = None
     httpHeaders: Optional[List[HTTPHeader]] = None
     path: Optional[str] = None
@@ -3163,7 +3163,7 @@ class TCPSocketAction(K8sSpec):
 
     """
 
-    port: str
+    port: int | str
     host: Optional[str] = None
 
 
@@ -5212,7 +5212,7 @@ class ServicePort(K8sSpec):
     name: Optional[str] = None
     nodePort: Optional[int] = None
     protocol: Optional[str] = None
-    targetPort: Optional[str] = None
+    targetPort: Optional[int | str] = None
 
 
 @dataclass

--- a/gybe/k8s/v1_34/networking/v1.py
+++ b/gybe/k8s/v1_34/networking/v1.py
@@ -437,7 +437,7 @@ class NetworkPolicyPort(K8sSpec):
     """
 
     endPort: Optional[int] = None
-    port: Optional[str] = None
+    port: Optional[int | str] = None
     protocol: Optional[str] = None
 
 

--- a/gybe/k8s/v1_34/policy/v1.py
+++ b/gybe/k8s/v1_34/policy/v1.py
@@ -86,8 +86,8 @@ class PodDisruptionBudgetSpec(K8sSpec):
 
     """
 
-    maxUnavailable: Optional[str] = None
-    minAvailable: Optional[str] = None
+    maxUnavailable: Optional[int | str] = None
+    minAvailable: Optional[int | str] = None
     selector: Optional[gybe.k8s.v1_34.meta.v1.LabelSelector] = None
     unhealthyPodEvictionPolicy: Optional[str] = None
 


### PR DESCRIPTION
Respecting the JSON schema here is the cleanest way to implement this since many of these fields have k8s server level validations that will be tricky to replicate reliably in gybe's type checks.